### PR TITLE
Add support for multiple hulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ These methods are used in d3-geo-voronoi’s [geoContour](https://github.com/Fil
 
 Sets the *triangulate* function. Defaults to d3.Delaunay.from. See [Reusing a  tricontour triangulation](https://observablehq.com/@fil/reusing-a-tricontour-triangulation) and [UK tricontour](https://observablehq.com/@fil/tricontours-with-a-personalized-triangulation) for detailed examples.
 
+The *triangulate* function should create an object which is compatible with d3.Delaunay, i.e. it must have `points`, `halfedges`, `hull` and `triangles`.
+However, in order to support hulls made up of multiple connected components, `hull` does not have to be an `Int32Array` but can be an `Array` of `Int32Array` (one per connected component of the hull).
+This allows to handle the case where the domain is made up of multiple pieces and/or has holes.
+
 [<img src="https://raw.githubusercontent.com/Fil/d3-tricontour/main/img/tricontour-triangulation.jpg" alt="UK tricontour" width="320">](https://observablehq.com/@fil/tricontours-with-a-personalized-triangulation)
 
 


### PR DESCRIPTION
As mentioned in the [UK Tricontours example](https://observablehq.com/@fil/tricontours-with-a-personalized-triangulation?collection=@fil/tricontours):

> The triangulation does not need to be Delaunay, nor to be convex, for tricontours to work. It must however be properly defined, and have only one hull. (If it has disconnected pieces, you will need to run the tricontours for each piece, or upgrade the algorithm and data structure.)

This PR is a proposed implementation of the upgrade mentioned in the case where there are multiple hulls. This is useful for two different cases: when the domain is a single connected component but is multiply connected (i.e. it's in one piece but it has holes), and/or when the domain is made up of several connected components.

This upgrade required very few changes in the code and is backwards compatible. 

I saw there is a `test` folder in the repo, but I don't know how to run the test suite, so I did not add a test. If that is something you would like me to add, I'd be happy to exchange on how you test this repo. For my own purposes, the new implementation works correctly, even in cases where there are several connected components and each has several holes.